### PR TITLE
Update HoxHudLocalisationFR.json

### DIFF
--- a/HoxHud/HoxHudLocalisationFR.json
+++ b/HoxHud/HoxHudLocalisationFR.json
@@ -273,7 +273,7 @@
 		  "menu_hoxhud_credits": "Crédits de HoxHud",
 		 "menu_hoxhud_credits_help": "Voir les crédits de HoxHud",
              "menu_difficulty_overkill_145": "Overkill",
-       "menu_difficulty_overkill_290": "Deathwish",
+       "menu_difficulty_overkill_290": "Suicidaire",
                "menu_fastnet": "Fast.net",
             "menu_fastnet_help": "Démarrer rapidement un lobby",
            "fastnet_buy_contract": "Acheter un contrat",


### PR DESCRIPTION
Tiny update: the "Deathwish" word was localized in French in the last versions so it has been updated here to be the same ("Suicidaire").
